### PR TITLE
refactor: use roleType for involvedPersons filtering

### DIFF
--- a/src/api/globalSearch.ts
+++ b/src/api/globalSearch.ts
@@ -36,12 +36,12 @@ const setHistory = (queryParams: string) => {
 }
 
 const getInventor = (item: any):string => {
-  const inventor = item.involved_persons.find((person: any) => person.role === 'Inventor');
+  const inventor = item.involved_persons.find((person: any) => person.roleType === 'INVENTOR');
   return inventor ? `${inventor.name}${inventor.suffix}` : '';
 }
 
 const getArtist = (item: any):string => {
-  const artist = item.involved_persons.find((person: any) => person.role === 'Künstler');
+  const artist = item.involved_persons.find((person: any) => person.roleType === 'ARTIST');
   return artist ? artist.name : '';
 }
 


### PR DESCRIPTION
Da `involvedPerson`-Items nun das zusätzliche Feld `roleType` enthalten (Ableitung des Typs vom rohen Rollen-Wert zum Import-Vorgang), wird dieses nun auch für das Raussuchen des Inventor- bzw. Künstlernamens. Das sollte nun auch sprachunabhängig sein, da Rollen in den Rohdaten entweder auf deutsch oder auf englisch hinterlegt waren.