### PR TITLE
Routing Rework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "mobx-react-lite": "^3.2.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-i18next": "^11.11.4",
-        "react-router-dom": "^5.2.0"
+        "react-i18next": "^11.11.4"
       },
       "devDependencies": {
         "@types/react": "^17.0.0",
@@ -1433,14 +1432,6 @@
         "@babel/runtime": "^7.7.6"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
@@ -1746,11 +1737,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2116,19 +2102,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2400,14 +2373,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -2580,16 +2545,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2666,11 +2621,6 @@
         "react": ">= 16.8.0"
       }
     },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/react-refresh": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.10.0.tgz",
@@ -2678,69 +2628,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-router-dom/node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
       }
     },
     "node_modules/read-pkg": {
@@ -2944,11 +2831,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -3512,16 +3394,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -3689,11 +3561,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/vfile": {
       "version": "4.2.1",
@@ -4916,14 +4783,6 @@
         "@babel/runtime": "^7.7.6"
       }
     },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "requires": {
-        "react-is": "^16.7.0"
-      }
-    },
     "hosted-git-info": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
@@ -5141,11 +5000,6 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -5411,15 +5265,6 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
-    "mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      }
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -5613,14 +5458,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "requires": {
-        "isarray": "0.0.1"
-      }
-    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -5752,16 +5589,6 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -5808,77 +5635,11 @@
         "html-parse-stringify": "^3.0.1"
       }
     },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "react-refresh": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.10.0.tgz",
       "integrity": "sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==",
       "dev": true
-    },
-    "react-router": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "history": {
-          "version": "4.10.1",
-          "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-          "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-          "requires": {
-            "@babel/runtime": "^7.1.2",
-            "loose-envify": "^1.2.0",
-            "resolve-pathname": "^3.0.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0",
-            "value-equal": "^1.0.1"
-          }
-        }
-      }
-    },
-    "react-router-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "history": {
-          "version": "4.10.1",
-          "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-          "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-          "requires": {
-            "@babel/runtime": "^7.1.2",
-            "loose-envify": "^1.2.0",
-            "resolve-pathname": "^3.0.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0",
-            "value-equal": "^1.0.1"
-          }
-        }
-      }
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -6034,11 +5795,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
-    },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -6461,16 +6217,6 @@
         "strip-ansi": "^6.0.0"
       }
     },
-    "tiny-invariant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -6595,11 +6341,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vfile": {
       "version": "4.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,10 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "cranach-search",
       "version": "0.0.0",
       "dependencies": {
+        "history": "^5.1.0",
         "i18next": "^20.4.0",
         "mobx": "^6.3.2",
         "mobx-react-lite": "^3.2.0",
@@ -1424,16 +1426,11 @@
       }
     },
     "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
+      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -2718,6 +2715,32 @@
       },
       "peerDependencies": {
         "react": ">=15"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
+    "node_modules/react-router/node_modules/history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
       }
     },
     "node_modules/read-pkg": {
@@ -4886,16 +4909,11 @@
       "dev": true
     },
     "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
+      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "hoist-non-react-statics": {
@@ -5816,6 +5834,21 @@
         "react-is": "^16.6.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "history": {
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+          "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "loose-envify": "^1.2.0",
+            "resolve-pathname": "^3.0.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0",
+            "value-equal": "^1.0.1"
+          }
+        }
       }
     },
     "react-router-dom": {
@@ -5830,6 +5863,21 @@
         "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "history": {
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+          "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "loose-envify": "^1.2.0",
+            "resolve-pathname": "^3.0.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0",
+            "value-equal": "^1.0.1"
+          }
+        }
       }
     },
     "read-pkg": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "cranach-search",
       "version": "0.0.0",
       "dependencies": {
         "history": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cranach-search",
   "version": "0.0.0",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc && vite build",
     "build:prod": "tsc && vite build --base=/search/",
     "serve": "vite preview",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "stylelint **/*.scss --fix"
   },
   "dependencies": {
+    "history": "^5.1.0",
     "i18next": "^20.4.0",
     "mobx": "^6.3.2",
     "mobx-react-lite": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "mobx-react-lite": "^3.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-i18next": "^11.11.4",
-    "react-router-dom": "^5.2.0"
+    "react-i18next": "^11.11.4"
   },
   "devDependencies": {
     "@types/react": "^17.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import Navigation from './components/structure/interacting/navigation';
 
 
 function App() {
-  const { ui } = useContext(StoreContext);
+  const { root: { ui } } = useContext(StoreContext);
   const history = useHistory();
   const match = useRouteMatch<{ lang: string }>(`${import.meta.env.BASE_URL}:lang`);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,28 +1,9 @@
-import React, { Fragment, useContext, useEffect } from 'react'
-import { useRouteMatch, useHistory } from 'react-router-dom'
-
-import StoreContext from './store/StoreContext';
+import React, { Fragment } from 'react'
 import Dashboard from './components/pages/dashboard';
 import Navigation from './components/structure/interacting/navigation';
 
 
 function App() {
-  const { root: { ui } } = useContext(StoreContext);
-  const history = useHistory();
-  const match = useRouteMatch<{ lang: string }>(`${import.meta.env.BASE_URL}:lang`);
-
-  useEffect(() => {
-    if(match && ui.allowedLangs.includes(match.params.lang)) {
-      ui.setLanguage(match.params.lang);
-    } else {
-      history.replace(`${import.meta.env.BASE_URL}${ui.lang}/`);
-    }
-  }, [ui.allowedLangs, match, history]);
-
-  useEffect(() => {
-    history.replace(`${import.meta.env.BASE_URL}${ui.lang}/`);
-  }, [ui.lang, history]);
-
   return (
     <Fragment>
       <Navigation></Navigation>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,25 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, useContext, useEffect } from 'react'
+import StoreContext from './store/StoreContext';
 import Dashboard from './components/pages/dashboard';
 import Navigation from './components/structure/interacting/navigation';
 
 
 function App() {
+  const { root: { routing, ui } } = useContext(StoreContext);
+
+  useEffect(() => {
+    const match = routing.history.location.pathname.match(/^\/([a-z]+)\//);
+    if(match && ui.allowedLangs.includes(match[1])) {
+      ui.setLanguage(match[1]);
+    } else {
+      routing.history.replace({ ...routing.history.location, pathname: `${import.meta.env.BASE_URL}${ui.lang}/` });
+    }
+  }, [ui.allowedLangs, routing.history]);
+
+  useEffect(() => {
+    routing.history.replace({ ...routing.history.location, pathname: `${import.meta.env.BASE_URL}${ui.lang}/` });
+  }, [ui.lang, routing.history]);
+
   return (
     <Fragment>
       <Navigation></Navigation>

--- a/src/api/globalSearch.ts
+++ b/src/api/globalSearch.ts
@@ -27,14 +27,6 @@ const assembleResultData = (resultset: any): GlobalSearchResult => {
   return { items, filterGroups, meta };
 }
 
-const setHistory = (queryParams: string) => {
-  const baseurl = location.protocol + '//' + location.host + location.pathname;
-  const nextState = { searchParams: queryParams };
-  const nextTitle = "cda_ // Search ";
-  const nextURL = `${baseurl}?${queryParams}`;
-  window.history.pushState(nextState, nextTitle, nextURL);
-}
-
 const getInventor = (item: any):string => {
   const inventor = item.involved_persons.find((person: any) => person.roleType === 'INVENTOR');
   return inventor ? `${inventor.name}${inventor.suffix}` : '';
@@ -148,8 +140,6 @@ const executeQuery = async (
   const authString = btoa(`${authUser}:${authPass}`);
   const headers = new Headers();
   headers.set('Authorization', 'Basic ' + authString);
-
-  setHistory(queryParams);
 
   try {
     const resp = await fetch(

--- a/src/api/globalSearch.ts
+++ b/src/api/globalSearch.ts
@@ -75,12 +75,12 @@ const searchByFiltersAndTerm = async (
     params['from'] = filters.from;
   }
 
-  if (filters.dating.from) {
-    params['dating_begin:gte'] = filters.dating.from;
+  if (filters.dating.fromYear) {
+    params['dating_begin:gte'] = filters.dating.fromYear;
   }
 
-  if (filters.dating.to) {
-    params['dating_end:lte'] = filters.dating.to;
+  if (filters.dating.toYear) {
+    params['dating_end:lte'] = filters.dating.toYear;
   }
 
   if (filters.id) {
@@ -190,8 +190,8 @@ export enum EntityTypeShortcuts {
 
 export type APIFilterType = {
   dating: {
-    from: string,
-    to: string,
+    fromYear: number,
+    toYear: number,
   },
   size: number,
   from: number,

--- a/src/components/pages/dashboard/dashboard.tsx
+++ b/src/components/pages/dashboard/dashboard.tsx
@@ -11,7 +11,7 @@ import StoreContext, { GlobalSearchEntityType, UIOverviewViewType } from '../../
 import './dashboard.scss';
 
 const Dashboard: FC = () => {
-  const { globalSearch, ui } = useContext(StoreContext);
+  const { root: { globalSearch, ui } } = useContext(StoreContext);
   const isActiveSidebar = 'dashboard__sidebar--is-active';
 
   useEffect(() => {

--- a/src/components/structure/interacting/my-cranach/my-cranach.tsx
+++ b/src/components/structure/interacting/my-cranach/my-cranach.tsx
@@ -8,7 +8,7 @@ import './my-cranach.scss';
 import StoreContext, { UISidebarType } from '../../../../store/StoreContext';
 
 const MyCranach = () => {
-  const { collection, ui } = useContext(StoreContext);
+  const { root: { collection, ui } } = useContext(StoreContext);
   const { t } = ui.useTranslation('Search', translations);
   const triggerComparism = () => collection.startComparism();
   const compareIsActive = collection.size && collection.size > 1 ? 'btn--is-active' : 'btn--is-disabled';

--- a/src/components/structure/interacting/navigation/navigation.tsx
+++ b/src/components/structure/interacting/navigation/navigation.tsx
@@ -13,7 +13,7 @@ import StoreContext, { GlobalSearchEntityType } from '../../../../store/StoreCon
 
 
 const Navigation = () => {
-  const { globalSearch, ui } = useContext(StoreContext);
+  const { root: { globalSearch, ui } } = useContext(StoreContext);
 
   const { t } = ui.useTranslation('Navigation', translations);
 

--- a/src/components/structure/interacting/search-result-navigation/search-result-navigation.tsx
+++ b/src/components/structure/interacting/search-result-navigation/search-result-navigation.tsx
@@ -24,7 +24,7 @@ const SearchResultNavigation: FC<Props> = ({
   const lastItemClass = `${paginationClass}--last-item`;
   const hiddenClass = `${paginationClass}--hidden`;
 
-  const { globalSearch } = useContext(StoreContext);
+  const { root: { globalSearch } } = useContext(StoreContext);
   const { size, from } = globalSearch.filters;
   const hits = globalSearch.result?.meta.hits ?? 0;
 

--- a/src/components/structure/interacting/search/search.tsx
+++ b/src/components/structure/interacting/search/search.tsx
@@ -18,7 +18,7 @@ import StoreContext, {
 } from '../../../../store/StoreContext';
 
 const Search: FC = () => {
-  const { globalSearch, ui } = useContext(StoreContext);
+  const { root: { globalSearch, ui } } = useContext(StoreContext);
 
   const { t } = ui.useTranslation('Search', translations);
 

--- a/src/components/structure/interacting/secondary-navigation/secondary-navigation.tsx
+++ b/src/components/structure/interacting/secondary-navigation/secondary-navigation.tsx
@@ -11,7 +11,7 @@ import StoreContext, { UIOverviewViewType, UISidebarType } from '../../../../sto
 
 
 const SecondaryNavigation = () => {
-  const { ui, collection, globalSearch } = useContext(StoreContext);
+  const { root: { ui, collection, globalSearch } } = useContext(StoreContext);
   const { t } = ui.useTranslation('Navigation', translations);
 
   const [isActive, setActive] = useState(false);

--- a/src/components/structure/visualizing/artefact-card/artefact-card.tsx
+++ b/src/components/structure/visualizing/artefact-card/artefact-card.tsx
@@ -32,7 +32,7 @@ const ArtefactCard: FC<Props> = ({
   openInNewWindow = false,
 }) => {
 
-  const { collection } = useContext(StoreContext);
+  const { root: { collection } } = useContext(StoreContext);
 
   let isStoredFavorite = !!(collection.artefacts.includes(storageSlug));
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,18 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { BrowserRouter as Router } from 'react-router-dom'
+import { Router } from 'react-router-dom'
+import { createBrowserHistory } from 'history';
 import StoreProvider from './providers/StoreProvider';
 import './style/main.scss'
 import App from './App'
 
+// https://github.com/superwf/mobx-react-router
+const history = createBrowserHistory();
+
 ReactDOM.render(
   <React.StrictMode>
     <StoreProvider>
-      <Router>
+      <Router history={history}>
         <App />
       </Router>
     </StoreProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Router } from 'react-router-dom'
-import { createBrowserHistory } from 'history';
 import StoreProvider from './providers/StoreProvider';
+import { createBrowserHistory } from 'history';
 import './style/main.scss'
 import App from './App'
 
@@ -11,7 +11,7 @@ const history = createBrowserHistory();
 
 ReactDOM.render(
   <React.StrictMode>
-    <StoreProvider>
+    <StoreProvider history={history}>
       <Router history={history}>
         <App />
       </Router>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,20 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { Router } from 'react-router-dom'
 import StoreProvider from './providers/StoreProvider';
-import { createBrowserHistory } from 'history';
 import './style/main.scss'
 import App from './App'
 
-// https://github.com/superwf/mobx-react-router
-const history = createBrowserHistory();
-
 ReactDOM.render(
   <React.StrictMode>
-    <StoreProvider history={history}>
-      <Router history={history}>
-        <App />
-      </Router>
+    <StoreProvider>
+      <App />
     </StoreProvider>
   </React.StrictMode>,
   document.getElementById('root')

--- a/src/providers/StoreProvider.tsx
+++ b/src/providers/StoreProvider.tsx
@@ -1,15 +1,12 @@
 import React, { FC } from 'react';
-import { History } from 'history';
+import { createBrowserHistory } from 'history';
 
 import StoreContext from '../store/StoreContext';
 import RootStore from '../store/rootStore';
 
+const history = createBrowserHistory();
 
-type StoreProviderProps = {
-  history: History;
-};
-
-const StoreProvider: FC<StoreProviderProps> = ({ children, history }) => {
+const StoreProvider: FC = ({ children }) => {
   const root = new RootStore(history);
 
   return (

--- a/src/providers/StoreProvider.tsx
+++ b/src/providers/StoreProvider.tsx
@@ -1,19 +1,22 @@
 import React, { FC } from 'react';
+import { History } from 'history';
 
 import StoreContext from '../store/StoreContext';
+import RootStore from '../store/rootStore';
 
-import { UI, GlobalSearch, Collection } from '../store';
-import globalSearchAPI from '../api/globalSearch';
 
-const ui = new UI();
+type StoreProviderProps = {
+  history: History;
+};
 
-const globalSearch = new GlobalSearch(ui, globalSearchAPI);
-const collection = new Collection(globalSearch);
+const StoreProvider: FC<StoreProviderProps> = ({ children, history }) => {
+  const root = new RootStore(history);
 
-const StoreProvider: FC = ({ children }) => (
-  <StoreContext.Provider value={ { ui, globalSearch, collection } }>
-    {children}
-  </StoreContext.Provider>
-);
+  return (
+    <StoreContext.Provider value={ { root } }>
+      {children}
+    </StoreContext.Provider>
+  );
+}
 
 export default StoreProvider

--- a/src/store/StoreContext.ts
+++ b/src/store/StoreContext.ts
@@ -1,9 +1,7 @@
 import { createContext } from 'react';
 import { configure } from 'mobx';
 
-import { UIStoreInterface } from './domains/ui';
-import { CollectionStoreInterface } from './domains/collection';
-import { GlobalSearchStoreInterface } from './domains/globalSearch';
+import { RootStoreInterface } from './rootStore';
 
 export { GlobalSearchEntityType } from './domains/globalSearch';
 export type {
@@ -17,9 +15,7 @@ configure({
 });
 
 type StoreDefaultType = {
-  ui: UIStoreInterface;
-  globalSearch: GlobalSearchStoreInterface;
-  collection: CollectionStoreInterface;
+  root: RootStoreInterface;
 }
 
 export default createContext<StoreDefaultType>({} as StoreDefaultType);

--- a/src/store/domains/collection.ts
+++ b/src/store/domains/collection.ts
@@ -1,16 +1,17 @@
 
 import { makeAutoObservable } from 'mobx';
-import GlobalSearch from './globalSearch';
+import { RootStoreInterface } from '../rootStore';
 
 const cranachCompareURL = import.meta.env.VITE_CRANACH_COMPARE_URL;
 
 export default class Collection implements CollectionStoreInterface {
+  rootStore: RootStoreInterface;
   artefacts: string[] = [];
-  globalSearchStore: GlobalSearch;
 
-  constructor(globalSearchStore: GlobalSearch) {
+  constructor(rootStore: RootStoreInterface) {
     makeAutoObservable(this);
-    this.globalSearchStore = globalSearchStore;
+
+    this.rootStore = rootStore;
     this.readCollectionFromLocalStorage();
   }
 
@@ -45,9 +46,9 @@ export default class Collection implements CollectionStoreInterface {
 
   showCollection() {
     this.readCollectionFromLocalStorage();
-    this.globalSearchStore.resetEntityType();
+    this.rootStore.globalSearch.resetEntityType();
     const artefactInventoryNumbers = this.artefacts.map(artefact => artefact.replace(/:.*/, ''));
-    this.globalSearchStore.triggerUserCollectionRequest(artefactInventoryNumbers);
+    this.rootStore.globalSearch.triggerUserCollectionRequest(artefactInventoryNumbers);
     return true;
   }
 

--- a/src/store/domains/globalSearch.ts
+++ b/src/store/domains/globalSearch.ts
@@ -38,17 +38,11 @@ export type FilterType = {
 
 export default class GlobalSearch implements GlobalSearchStoreInterface, RoutingObservableInterface {
   rootStore: RootStoreInterface;
-
   globalSearchAPI: GlobalSearchAPI;
-
   allFieldsTerm: string = '';
-
   loading: boolean = false;
-
   result: GlobalSearchResult | null = null;
-
   error: string | null = null;
-
   filters: FilterType = {
     dating: {
       fromYear: 0,
@@ -69,10 +63,8 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
 
     this.rootStore = rootStore;
     this.globalSearchAPI = globalSearchAPI;
-
     this.rootStore.routing.addObserver(this);
   }
-
 
   /* Computed */
 
@@ -233,12 +225,10 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
   private updateRoutingForFilterGroups(groupKey: string) {
     const groupSet = this.filters.filterGroups.get(groupKey);
     const routingActions: RoutingSearchQueryParamChange = [];
-
     const routingAction = !groupSet ? RoutingChangeAction.REMOVE : RoutingChangeAction.ADD;
-
     const gs = Array.from(this.filters.filterGroups.get(groupKey) || new Set()).join(',');
-    routingActions.push([routingAction, [groupKey, gs]]);
 
+    routingActions.push([routingAction, [groupKey, gs]]);
     this.rootStore.routing.updateSearchQueryParams(routingActions);
   }
 
@@ -288,51 +278,29 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
   }
 }
 
-
-
 export interface GlobalSearchStoreInterface {
   allFieldsTerm: string;
-
   loading: boolean;
-
   result: GlobalSearchResult | null;
-
   error: string | null;
-
   filters: FilterType;
-
   debounceWaitInMSecs: number;
-
   debounceHandler: undefined | number;
-
   flattenedSearchResultItems: GlobalSearchArtifact[];
 
   setAllFieldsTerm(allFieldsTerm: string): void;
-
   setSearchLoading(loading: boolean): void;
-
   setSearchResult(result: GlobalSearchResult | null): void;
-
   resetSearchResult(): void;
-
   setSearchFailed(error: string | null): void;
-
   searchForAllFieldsTerm(allFieldsTerm: string): void;
-
   setDatingFrom(fromYear: number): void;
-
   setDatingTo(toYear: number): void;
-
   setEntityType(entityType: EntityType): void;
-
   setFrom(from: number): void;
-
   toggleFilterItemActiveStatus(groupKey: string, filterItemId: string): void;
-
   triggerFilterRequest(): void;
-
   triggerUserCollectionRequest(ids: string[]): void;
-
   resetEntityType(): void;
 
 }

--- a/src/store/domains/globalSearch.ts
+++ b/src/store/domains/globalSearch.ts
@@ -234,7 +234,7 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
     const groupSet = this.filters.filterGroups.get(groupKey);
     const routingActions: RoutingSearchQueryParamChange = [];
 
-    let routingAction = !groupSet ? RoutingChangeAction.REMOVE : RoutingChangeAction.ADD;
+    const routingAction = !groupSet ? RoutingChangeAction.REMOVE : RoutingChangeAction.ADD;
 
     const gs = Array.from(this.filters.filterGroups.get(groupKey) || new Set()).join(',');
     routingActions.push([routingAction, [groupKey, gs]]);

--- a/src/store/domains/routing.ts
+++ b/src/store/domains/routing.ts
@@ -33,18 +33,7 @@ export default class Routing implements RoutingStoreInterface {
     this.rootStore = rootStore;
     this.history = history;
 
-    const subscribe = (listener: Listener) => {
-      const unlisten = history.listen(listener);
-
-      listener({
-        action: history.action,
-        location: history.location,
-      });
-
-      return unlisten;
-    }
-
-    history.listen(subscribe(this.updateState.bind(this)));
+    history.listen(this.updateState.bind(this));
   }
 
   /* Computed */
@@ -58,7 +47,7 @@ export default class Routing implements RoutingStoreInterface {
 
   updateState(newState: Update) {
     if (newState.location.search !== this.state.location.search) {
-      let searchParams = Array.from((new URLSearchParams(newState.location.search)).entries());
+      const searchParams = Array.from((new URLSearchParams(newState.location.search)).entries());
 
       this.notifyAllObservers({
         type: NotificationType.SEARCH_CHANGE,
@@ -103,7 +92,7 @@ export default class Routing implements RoutingStoreInterface {
   }
 
   notifyObserverWithCurrentSearchParams(observer: ObserverInterface) {
-    let searchParams = new URLSearchParams(this.state.location.search);
+    let { searchParams } = this;
 
     observer.notify({
       type: NotificationType.SEARCH_INIT,

--- a/src/store/domains/routing.ts
+++ b/src/store/domains/routing.ts
@@ -1,31 +1,147 @@
 
-import { makeAutoObservable } from 'mobx';
-
-import UI from './ui';
-import GlobalSearch from './globalSearch';
+import type { History, Listener, Update } from 'history'
+import { makeObservable, observable, action, computed } from 'mobx';
+import { Action } from 'history'
+import { RootStoreInterface } from '../rootStore';
 
 
 export default class Routing implements RoutingStoreInterface {
-  uiStore: UI;
+  rootStore: RootStoreInterface;
+  history: History;
+  disableNotify: boolean = false;
+  routingObservers: ObserverInterface[] = [];
 
-  globalSearch: GlobalSearch;
-
-  name: string = '';
-
-  constructor(uiStore: UI, globalSearch: GlobalSearch) {
-    makeAutoObservable(this);
-
-    this.uiStore = uiStore;
-    this.globalSearch = globalSearch;
+  public state: Update = {
+    action: Action.Pop,
+    location: {
+      key: 'default',
+      pathname: '',
+      search: '',
+      state: {},
+      hash: '',
+    },
   }
+
+  constructor(rootStore: RootStoreInterface, history: History) {
+    makeObservable(this, {
+        state: observable,
+        updateState: action,
+        searchParams: computed,
+        updateSearchQueryParams: action,
+    });
+
+    this.rootStore = rootStore;
+    this.history = history;
+
+    const subscribe = (listener: Listener) => {
+      const unlisten = history.listen(listener);
+
+      listener({
+        action: history.action,
+        location: history.location,
+      });
+
+      return unlisten;
+    }
+
+    history.listen(subscribe(this.updateState.bind(this)));
+  }
+
+  /* Computed */
+
+  get searchParams(): URLSearchParams {
+    return new URLSearchParams(this.state.location.search);
+  }
+
 
   /* Actions */
 
-  setName(name: string) {
-    this.name = name;
+  updateState(newState: Update) {
+    if (newState.location.search !== this.state.location.search) {
+      let searchParams = Array.from((new URLSearchParams(newState.location.search)).entries());
+
+      this.notifyAllObservers({
+        type: NotificationType.SEARCH_CHANGE,
+        params: searchParams,
+      });
+    }
+
+    this.state = {
+      action: newState.action,
+      location: { ...newState.location },
+    };
+  }
+
+  addObserver(observer: ObserverInterface) {
+    this.routingObservers.push(observer);
+
+    this.notifyObserverWithCurrentSearchParams(observer);
+  }
+
+  updateSearchQueryParams(change: SearchQueryParamChange) {
+    const currentSearchParams = this.searchParams;
+
+    const updatedSearchParams = change.reduce((acc, [action, [name, value]]) => {
+      switch (action) {
+        case ChangeAction.ADD:
+          currentSearchParams.set(name, value);
+          break;
+
+        case ChangeAction.REMOVE:
+          currentSearchParams.delete(name);
+          break;
+      }
+
+      return acc;
+    }, currentSearchParams)
+
+    this.disableNotify = true;
+    this.history.replace({
+      search: Array.from(updatedSearchParams).length ? `?${updatedSearchParams.toString()}` : '', 
+    });
+    this.disableNotify = false;
+  }
+
+  notifyObserverWithCurrentSearchParams(observer: ObserverInterface) {
+    let searchParams = new URLSearchParams(this.state.location.search);
+
+    observer.notify({
+      type: NotificationType.SEARCH_INIT,
+      params: Array.from(searchParams.entries()),
+    });
+  }
+
+  notifyAllObservers(notification: NotificationInterface) {
+    if (this.disableNotify) { return; }
+
+    this.routingObservers.forEach(observer => observer.notify(notification));
   }
 }
 
 export interface RoutingStoreInterface {
-  name: string;
+  history: History;
+
+  addObserver: (observer: ObserverInterface) => void;
+  updateSearchQueryParams: (change: SearchQueryParamChange) => void;
+}
+
+export enum NotificationType {
+  SEARCH_INIT = 'SEARCH_INIT',
+  SEARCH_CHANGE = 'SEARCH_CHANGE',
+}
+
+export enum ChangeAction {
+  ADD = 'ADD',
+  REMOVE = 'REMOVE',
+}
+
+export type SearchQueryParamChange = [ChangeAction, [string, string]][];
+
+export interface NotificationInterface {
+  type: NotificationType,
+  params: [string, string][],
+}
+
+export interface ObserverInterface {
+  notify: (notification: NotificationInterface) => void;
 }

--- a/src/store/domains/routing.ts
+++ b/src/store/domains/routing.ts
@@ -1,0 +1,31 @@
+
+import { makeAutoObservable } from 'mobx';
+
+import UI from './ui';
+import GlobalSearch from './globalSearch';
+
+
+export default class Routing implements RoutingStoreInterface {
+  uiStore: UI;
+
+  globalSearch: GlobalSearch;
+
+  name: string = '';
+
+  constructor(uiStore: UI, globalSearch: GlobalSearch) {
+    makeAutoObservable(this);
+
+    this.uiStore = uiStore;
+    this.globalSearch = globalSearch;
+  }
+
+  /* Actions */
+
+  setName(name: string) {
+    this.name = name;
+  }
+}
+
+export interface RoutingStoreInterface {
+  name: string;
+}

--- a/src/store/domains/routing.ts
+++ b/src/store/domains/routing.ts
@@ -4,7 +4,6 @@ import { makeObservable, observable, action, computed } from 'mobx';
 import { Action } from 'history'
 import { RootStoreInterface } from '../rootStore';
 
-
 export default class Routing implements RoutingStoreInterface {
   rootStore: RootStoreInterface;
   history: History;
@@ -42,7 +41,6 @@ export default class Routing implements RoutingStoreInterface {
     return new URLSearchParams(this.state.location.search);
   }
 
-
   /* Actions */
 
   updateState(newState: Update) {
@@ -63,7 +61,6 @@ export default class Routing implements RoutingStoreInterface {
 
   addObserver(observer: ObserverInterface) {
     this.routingObservers.push(observer);
-
     this.notifyObserverWithCurrentSearchParams(observer);
   }
 
@@ -86,7 +83,7 @@ export default class Routing implements RoutingStoreInterface {
 
     this.disableNotify = true;
     this.history.replace({
-      search: Array.from(updatedSearchParams).length ? `?${updatedSearchParams.toString()}` : '', 
+      search: Array.from(updatedSearchParams).length ? `?${updatedSearchParams.toString()}` : '',
     });
     this.disableNotify = false;
   }

--- a/src/store/domains/ui.ts
+++ b/src/store/domains/ui.ts
@@ -1,4 +1,3 @@
-
 import { makeAutoObservable } from 'mobx';
 import i18n from 'i18next';
 import {
@@ -7,7 +6,6 @@ import {
   UseTranslationResponse,
 } from 'react-i18next';
 import { RootStoreInterface } from '../rootStore';
-
 
 export default class UI implements UIStoreInterface {
   rootStore: RootStoreInterface

--- a/src/store/domains/ui.ts
+++ b/src/store/domains/ui.ts
@@ -6,16 +6,20 @@ import {
   useTranslation,
   UseTranslationResponse,
 } from 'react-i18next';
+import { RootStoreInterface } from '../rootStore';
 
 
 export default class UI implements UIStoreInterface {
+  rootStore: RootStoreInterface
   lang: string = 'de';
   sidebar: UISidebarType = UISidebarType.FILTER;
   overviewViewType: UIOverviewViewType = UIOverviewViewType.CARD;
   allowedLangs: string[] = ['de', 'en'];
 
-  constructor() {
+  constructor(rootStore: RootStoreInterface) {
     makeAutoObservable(this);
+
+    this.rootStore = rootStore;
 
     i18n
     .use(initReactI18next)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,8 +1,0 @@
-
-import UI_ from './domains/ui';
-import GlobalSearch_ from './domains/globalSearch';
-import Collection_ from './domains/collection';
-
-export const UI = UI_;
-export const GlobalSearch = GlobalSearch_;
-export const Collection = Collection_;

--- a/src/store/rootStore.ts
+++ b/src/store/rootStore.ts
@@ -8,7 +8,6 @@ import Routing, { RoutingStoreInterface } from './domains/routing';
 import GlobalSearch, { GlobalSearchStoreInterface } from './domains/globalSearch';
 import Collection, { CollectionStoreInterface } from './domains/collection';
 
-
 export default class RootStore implements RootStoreInterface {
   public ui: UIStoreInterface;
   public routing: RoutingStoreInterface;
@@ -23,7 +22,6 @@ export default class RootStore implements RootStoreInterface {
     this.globalSearch = new GlobalSearch(this, globalSearchAPI);
     this.collection = new Collection(this);
   }
-
 }
 
 export interface RootStoreInterface {

--- a/src/store/rootStore.ts
+++ b/src/store/rootStore.ts
@@ -1,0 +1,34 @@
+import { makeAutoObservable } from 'mobx';
+import { History } from 'history';
+
+import globalSearchAPI from '../api/globalSearch';
+
+import UI, { UIStoreInterface } from './domains/ui';
+import Routing, { RoutingStoreInterface } from './domains/routing';
+import GlobalSearch, { GlobalSearchStoreInterface } from './domains/globalSearch';
+import Collection, { CollectionStoreInterface } from './domains/collection';
+
+
+export default class RootStore implements RootStoreInterface {
+  public ui: UIStoreInterface;
+  public routing: RoutingStoreInterface;
+  public globalSearch: GlobalSearchStoreInterface;
+  public collection: CollectionStoreInterface;
+
+  constructor(history: History) {
+    makeAutoObservable(this);
+
+    this.ui = new UI(this);
+    this.routing = new Routing(this, history);
+    this.globalSearch = new GlobalSearch(this, globalSearchAPI);
+    this.collection = new Collection(this);
+  }
+
+}
+
+export interface RootStoreInterface {
+  ui: UIStoreInterface,
+  routing: RoutingStoreInterface,
+  globalSearch: GlobalSearchStoreInterface,
+  collection: CollectionStoreInterface,
+}


### PR DESCRIPTION
Mit diesem PR wird ein flexibleres Routing eingeführt.

Konkrete Features:

- Neuer Root-Store, der es allen Stores ermöglicht, mit anderen Stores zu kommunizieren
  - Damit zusammen hängen Anpassungen an Komponenten und dem ContextProvider / -Consumer, um vom rootStore als zentralen Store auszugehen, von dem Unter-Stores aus erreichbar sind
- Ein neuer Routing-Store, der auf History-Changes hört und diese Changes an relevante Stellen durchreicht, aber auch Anweisungen erhalten kann, die History zu aktualisieren

Als erster Schritt wurde die Kommunikation zwischen Routing- und GlobalSearch-Store aufgebaut, damit beim Setzen eines Filters der GlobalSearch-Store den Routing-Store bitten kann, entsprechende Search-Parameter zu setzen oder wieder zu entfernen. Zudem kümmert sich der Routing-Store ebenfalls darum, bei einem Seitenaufruf oder bei einer Änderung an der Location (z.B. Search-Parameter), diese Informationen an den GlobalSearch-Store durchzugeben.
Hier gibt es die Besonderheit, dass der GlobalSearch-Store nur die Search-Parameter auswertet, die er selbst anhand des Namens kennt bzw. dem Routing-Store so durchgibt.
