### PR TITLE
added function to store search result ids in local storage

### DIFF
--- a/src/store/domains/globalSearch.ts
+++ b/src/store/domains/globalSearch.ts
@@ -140,6 +140,16 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
     this.result = null;
   }
 
+  storeSearchResult(result: GlobalSearchResult | null) {
+    if (result === null) return;
+    this.result = result;
+
+    const artefactIds = this.result.items.map(item => item.id);
+    localStorage.setItem('searchResult', artefactIds.join(','));
+
+    return true;
+  }
+
   setSearchFailed(error: string | null) {
     this.error = error;
   }
@@ -246,6 +256,7 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
           lang,
         );
         this.setSearchResult(result);
+        this.storeSearchResult(result);
       } catch(err: any) {
         this.setSearchFailed(err.toString());
       } finally {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ import reactRefresh from '@vitejs/plugin-react-refresh'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [reactRefresh()],
+  server: {
+    port: 8080
+  }
 });


### PR DESCRIPTION
Hi,

damit man auf den Artefact Seiten via Pfeil zum nächsten Artefact der Suche springen kann, brauche ich die IDs der letzten Suche im Local Storage.

Bitte mal checken. Danke!

c.