### PR TITLE
fix(globalSearch): check correctly for entityType param value

### DIFF
--- a/src/store/domains/globalSearch.ts
+++ b/src/store/domains/globalSearch.ts
@@ -358,7 +358,7 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
   }
 
   private handleRoutingNotificationForEntityType(value: string) {
-    if (value in Object.keys(EntityType)){
+    if (Object.values(EntityType).includes(value as EntityType)){
       this.filters.entityType = value as EntityType;
     }
   }


### PR DESCRIPTION
Mit diesem PR wird der kind-QueryParameter nun auch korrekt ausgelesen und als Filter (entityType) gesetzt.