### PR TITLE
Zweite Anfrage für die Abbildung der Suche 

### DIFF
--- a/src/api/globalSearch.ts
+++ b/src/api/globalSearch.ts
@@ -151,6 +151,7 @@ const searchByFiltersAndTerm = async (
   }
 
   const queryParams = querify(params);
+  storeQueryInLocalStorage(queryParams);
 
   try {
     return await executeQuery(queryParams);
@@ -181,6 +182,11 @@ const retrieveUserCollection = async (
 
   return null;
 };
+
+const storeQueryInLocalStorage = (queryParams: string): void => {
+  if (queryParams === null) return;
+  localStorage.setItem('searchQueryParams', queryParams);
+}
 
 const executeQuery = async (
   queryParams: string

--- a/src/api/globalSearch.ts
+++ b/src/api/globalSearch.ts
@@ -85,11 +85,11 @@ const toArtefact = (item: any): GlobalSearchArtifact => {
   }
 };
 
-const searchByFiltersAndTerm = async (
+const getQueryStringForFiltersAndTerm = (
   filters: APIFilterType,
   freetextFields: APIFreetextFieldsType,
   langCode: string
-): Promise<GlobalSearchResult | null> => {
+): string => {
   const params: Record<string, string | number> = {
     language: langCode,
     sort_by: 'sorting_number.asc',
@@ -150,8 +150,19 @@ const searchByFiltersAndTerm = async (
     params['inventory_number:eq'] = cleanInventoryNumber;
   }
 
-  const queryParams = querify(params);
-  storeQueryInLocalStorage(queryParams);
+  return querify(params);
+};
+
+const searchByFiltersAndTerm = async (
+  filters: APIFilterType,
+  freetextFields: APIFreetextFieldsType,
+  langCode: string
+): Promise<GlobalSearchResult | null> => {
+  const queryParams = getQueryStringForFiltersAndTerm(
+    filters,
+    freetextFields,
+    langCode,
+  );
 
   try {
     return await executeQuery(queryParams);
@@ -183,11 +194,6 @@ const retrieveUserCollection = async (
   return null;
 };
 
-const storeQueryInLocalStorage = (queryParams: string): void => {
-  if (queryParams === null) return;
-  localStorage.setItem('searchQueryParams', queryParams);
-}
-
 const executeQuery = async (
   queryParams: string
 ): Promise<GlobalSearchResult | null> => {
@@ -212,19 +218,9 @@ const executeQuery = async (
 
 
 export default {
-  async searchByFiltersAndTerm(
-    filters: APIFilterType,
-    freetextFields: APIFreetextFieldsType,
-    lang: string,
-  ): Promise<GlobalSearchResult | null> {
-    return await searchByFiltersAndTerm(filters, freetextFields, lang);
-  },
-  async retrieveUserCollection(
-    ids: string[],
-    lang: string,
-  ): Promise<GlobalSearchResult | null> {
-    return await retrieveUserCollection(ids, lang);
-  }
+  getQueryStringForFiltersAndTerm,
+  searchByFiltersAndTerm,
+  retrieveUserCollection,
 };
 
 export enum EntityType {

--- a/src/components/structure/interacting/search/search.tsx
+++ b/src/components/structure/interacting/search/search.tsx
@@ -69,7 +69,7 @@ const Search: FC = () => {
     >
       <div className="search-result-info">
         {hits === 1 && <p><Size size={hits} /> {t('work found')}</p>}
-        {hits > 1 || hits ===0 && <p><Size size={hits} /> { t('works found') }</p>}
+        {(hits > 1 || hits === 0) && <p><Size size={hits} /> { t('works found') }</p>}
       </div>
       <fieldset className="block keyword-search">
         <TextInput

--- a/src/components/structure/visualizing/artefact-line/artefact-line.tsx
+++ b/src/components/structure/visualizing/artefact-line/artefact-line.tsx
@@ -26,7 +26,7 @@ const ArtefactLine: FC<Props> = ({
   imgAlt = '',
 }) => {
 
-  const additionalTextString = additionalText.map(item => (<p className="artefact-line__text">{item}</p>));
+  const additionalTextString = additionalText.map((item, index) => (<p key={index} className="artefact-line__text">{item}</p>));
 
   return (<div
     className="artefact-line"

--- a/src/store/domains/globalSearch.ts
+++ b/src/store/domains/globalSearch.ts
@@ -295,20 +295,36 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
         );
         this.setSearchResult(result);
 
-        updatedFilters.size = updatedFilters.size * 2;
-        const resultForInAcrtefactNavigation = await this.globalSearchAPI.searchByFiltersAndTerm(
-          updatedFilters,
-          this.freetextFields,
-          lang,
+        this.storeQueryParamsInLocalStorage(
+          this.globalSearchAPI.getQueryStringForFiltersAndTerm(
+            updatedFilters,
+            this.freetextFields,
+            lang,
+          ),
         );
-        this.storeSearchResultInLocalStorage(resultForInAcrtefactNavigation);
 
+        await this.triggerExtendedFilterRequestForLocalStorage(updatedFilters, lang);
       } catch(err: any) {
         this.setSearchFailed(err.toString());
       } finally {
         this.setSearchLoading(false);
       }
     }, this.debounceWaitInMSecs);
+  }
+
+  private storeQueryParamsInLocalStorage(queryParams: string): void {
+      if (queryParams === null) return;
+      localStorage.setItem('searchQueryParams', queryParams);
+  }
+
+  private async triggerExtendedFilterRequestForLocalStorage(filters: FilterType, lang: string): Promise<void> {
+    const extendedFilters = { ...filters, size: filters.size * 2 };
+    const resultForInAcrtefactNavigation = await this.globalSearchAPI.searchByFiltersAndTerm(
+      extendedFilters,
+      this.freetextFields,
+      lang,
+    );
+    this.storeSearchResultInLocalStorage(resultForInAcrtefactNavigation);
   }
 
   triggerUserCollectionRequest(ids: string[]) {

--- a/src/store/domains/globalSearch.ts
+++ b/src/store/domains/globalSearch.ts
@@ -134,7 +134,6 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
     const sizeChanged = curr.size !== init.size;
     const fromChanged = curr.from !== init.from;
     const entityTypeChanged = curr.entityType !== init.entityType;
-    const idChanged = curr.id !== init.id;
     const filterGroupsChanged = curr.filterGroups.size !== init.filterGroups.size;
     const isBestOfChanged = curr.isBestOf !== init.isBestOf;
 
@@ -143,7 +142,6 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
       sizeChanged,
       fromChanged,
       entityTypeChanged,
-      idChanged,
       filterGroupsChanged,
       isBestOfChanged,
     ].filter((item) => item).length;

--- a/src/store/domains/globalSearch.ts
+++ b/src/store/domains/globalSearch.ts
@@ -303,7 +303,7 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
           ),
         );
 
-        await this.triggerExtendedFilterRequestForLocalStorage(updatedFilters, lang);
+        this.triggerExtendedFilterRequestForLocalStorage(updatedFilters, lang);
       } catch(err: any) {
         this.setSearchFailed(err.toString());
       } finally {

--- a/src/store/domains/globalSearch.ts
+++ b/src/store/domains/globalSearch.ts
@@ -179,10 +179,11 @@ export default class GlobalSearch implements GlobalSearchStoreInterface, Routing
     if (result === null) return;
 
     const artefactIds = result.items.map(item => {
-      const id = item.id;
+      const { id } = item;
+      const { entityType } = item;
       const pattern = `.*${id}`;
       const imgSrc = item.imgSrc.replace(pattern, id);
-      return { id, imgSrc }
+      return { id, imgSrc, entityType }
     });
 
     const artefactIdsJson = JSON.stringify(artefactIds);


### PR DESCRIPTION
Hi,

ich habe mal, in Absprache mit Volker, eine zweiten Request eingebaut, der die doppelte Menge an Artefakten abfragt. Diese werden dann im Local Storage gespeichert, damit man auf der Artefact Ebene jenseits der Paginierungsgrenzen linear navigieren kann. 

Ist so nicht ganz so elegant … aber erschien erst mal am geradlinigsten. Volker würde demnächst mal eine Anfrage in der API Bereitstellen, die etwas schlankere Daten liefert. Die könnte man dann nutzen, um den Payload zu reduzieren.

lg. c