### PR TITLE
fix(sort): remove sorting param and fall back to default api sorting

### DIFF
--- a/src/api/globalSearch.ts
+++ b/src/api/globalSearch.ts
@@ -92,7 +92,6 @@ const getQueryStringForFiltersAndTerm = (
 ): string => {
   const params: Record<string, string | number> = {
     language: langCode,
-    sort_by: 'sorting_number.asc',
     'entity_type:neq': EntityType.DOCUMENTS,
     'size_height:gt': 200, // 9000: 2; 8000: 129; 7000: 393
   };


### PR DESCRIPTION
Müssen hier leider den Sorting-Parameter für Requests an die API entfernen, da das Default-Sorting-Verhalten der API auf die aufgebrochene Sortingnumber zurückfällt.

Fürs erste sollte es kein Problem sein. Sollte aber vllt. in Zukunft leicht überarbeitet werden.