### PR TITLE
fix(api): use locations- instead of collection_repository-param for locations search

### DIFF
--- a/src/api/globalSearch.ts
+++ b/src/api/globalSearch.ts
@@ -140,7 +140,7 @@ const getQueryStringForFiltersAndTerm = (
 
   const cleanLocation = freetextFields.location.trim();
   if (cleanLocation) {
-    params['collection_repository:sim'] = cleanLocation;
+    params['locations:sim'] = cleanLocation;
   }
 
   const cleanInventoryNumber = freetextFields.inventoryNumber.trim();


### PR DESCRIPTION
Mit diesem PR läuft die Standort-Suche (über das Standort-Eingabefeld) nun über die `locations`-Daten der Objekte.

Dies bedeutet nun auch, dass Grafikabzüge über ihre Werknormdaten gefunden werden, wenn nach Standort gesucht wird.
Als Beispiel: "Cleveland" oder "Gotha"