### PR TITLE
fix(filter): store open-status of the dating-filter

### DIFF
--- a/src/components/structure/interacting/search/search.tsx
+++ b/src/components/structure/interacting/search/search.tsx
@@ -172,7 +172,8 @@ const Search: FC = () => {
         <Accordion>
           <Accordion.Entry
             title={ t('Dating') }
-            isOpen={ false }
+            isOpen={ ui.filterItemIsExpanded('dating') }
+            onToggle={ (isOpen) => ui.setFilterItemExpandedState('dating', isOpen) }
           >
             <DatingRangeslider
               bounds={globalSearch.datingRangeBounds}


### PR DESCRIPTION
Dieser PR behebt einen Bug mit dem Dating-Filter, der durch den https://github.com/lucascranach/cranach-search/pull/70 PR eingeführt wurde und sich dadurch bemerkbar gemacht hat, dass das Accordion-Item für die Datierung nicht mehr öffnen lässt.