### PR TITLE
feat(artefact-card): hide content-block if presentable data is missing

### DIFF
--- a/src/components/structure/visualizing/artefact-card/artefact-card.tsx
+++ b/src/components/structure/visualizing/artefact-card/artefact-card.tsx
@@ -60,7 +60,7 @@ const ArtefactCard: FC<Props> = ({
           onClick={onFavoriteToggle || (() => {})}
         >{isFavorite ? 'remove' : 'add'}</a>)}
       </div>
-      {id
+      {(id && (title || subtitle || text))
         && (
           <div className="artefact-card__content">
             <a


### PR DESCRIPTION
Vorher:
![Bildschirmfoto 2022-08-07 um 16 24 34](https://user-images.githubusercontent.com/1864692/183295513-a0f921fc-5952-4558-8966-28b94540ab3e.png)

Nachher:
![Bildschirmfoto 2022-08-07 um 16 23 01](https://user-images.githubusercontent.com/1864692/183295482-b6721bea-f0b2-4635-9cee-1cf1b1134e8b.png)