### PR TITLE
Introduce table-view for ArtifactOverview

### DIFF
--- a/src/components/pages/dashboard/dashboard.tsx
+++ b/src/components/pages/dashboard/dashboard.tsx
@@ -48,6 +48,7 @@ const Dashboard: FC = () => {
     [UIOverviewViewType.CARD]: ArtefactOverviewType.CARD,
     [UIOverviewViewType.CARD_SMALL]: ArtefactOverviewType.CARD_SMALL,
     [UIOverviewViewType.LIST]: ArtefactOverviewType.LIST,
+    [UIOverviewViewType.TABLE]: ArtefactOverviewType.TABLE,
   })[type];
 
   return (

--- a/src/components/structure/interacting/secondary-navigation/secondary-navigation.tsx
+++ b/src/components/structure/interacting/secondary-navigation/secondary-navigation.tsx
@@ -46,6 +46,7 @@ const SecondaryNavigation = () => {
     [UIOverviewViewType.CARD]: ArtefactOverviewType.CARD,
     [UIOverviewViewType.CARD_SMALL]: ArtefactOverviewType.CARD_SMALL,
     [UIOverviewViewType.LIST]: ArtefactOverviewType.LIST,
+    [UIOverviewViewType.TABLE]: ArtefactOverviewType.TABLE,
   };
 
   /* We also need a map to map back from ArtefactOverview enum values to UIOverviewViewType enum values */
@@ -53,6 +54,7 @@ const SecondaryNavigation = () => {
     [ArtefactOverviewType.CARD]: UIOverviewViewType.CARD,
     [ArtefactOverviewType.CARD_SMALL]: UIOverviewViewType.CARD_SMALL,
     [ArtefactOverviewType.LIST]: UIOverviewViewType.LIST,
+    [ArtefactOverviewType.TABLE]: UIOverviewViewType.TABLE,
   }
 
   return (

--- a/src/components/structure/visualizing/artefact-overview/artefact-overview.scss
+++ b/src/components/structure/visualizing/artefact-overview/artefact-overview.scss
@@ -2,29 +2,37 @@
 @import "../../../../style//000-abstracts/mixins";
 
 .artefact-overview {
-  display: grid;
   align-content: flex-start;
-  padding-bottom: $xxl;
-  gap: $s;
   height: 100%;
+  padding-bottom: $xxl;
 
-  @include grid-auto-columns();
+  &--is-grid {
+    display: grid;
+    gap: $s;
 
-  &[data-active-view="card-small"] {
-    column-gap: $xxs !important;
-    row-gap: $xxs !important;
-    @include grid-auto-columns-small();
+
+    @include grid-auto-columns();
+
+    &[data-active-view="card-small"] {
+      column-gap: $xxs !important;
+      row-gap: $xxs !important;
+      @include grid-auto-columns-small();
+    }
+
+    &[data-active-view="list"] {
+      display: grid;
+      padding: $xs;
+      column-gap: $xs !important;
+      row-gap: $xs !important;
+
+      @include grid-even-columns($vp-xlarge, 2);
+      @include grid-even-columns($vp-xxlarge, 3);
+      @include grid-even-columns($vp-4xlarge, 4);
+    }
   }
 
-  &[data-active-view="list"] {
-    display: grid;
-    padding: $xs;
-    column-gap: $xs !important;
-    row-gap: $xs !important;
+  &--is-table {
 
-    @include grid-even-columns($vp-xlarge, 2);
-    @include grid-even-columns($vp-xxlarge, 3);
-    @include grid-even-columns($vp-4xlarge, 4);
   }
 
   &-switcher {

--- a/src/components/structure/visualizing/artefact-overview/artefact-overview.tsx
+++ b/src/components/structure/visualizing/artefact-overview/artefact-overview.tsx
@@ -264,7 +264,6 @@ const Overview: FC<OverviewProps> = ({
       ArtefactOverviewType.TABLE === viewType && <ArtefactTable
         head={ tableData.head }
         items={ tableData.items }
-        getIsFavorite={isFavorite}
         onFavoriteToggle={toggleFavorite}
       ></ArtefactTable>
     }

--- a/src/components/structure/visualizing/artefact-overview/artefact-overview.tsx
+++ b/src/components/structure/visualizing/artefact-overview/artefact-overview.tsx
@@ -2,11 +2,13 @@ import React, { FC, useRef, useEffect, useContext } from 'react';
 import Switcher from '../../../base/interacting/switcher';
 import ArtefactCard from '../artefact-card';
 import ArtefactLine from '../artefact-line';
+import ArtefactTable, { Props as ArtefactTableProps } from '../artefact-table';
 
 import { observer } from 'mobx-react-lite';
 
-import StoreContext, { EntityType } from '../../../../store/StoreContext';
+import StoreContext, { EntityType, UIArtifactKind } from '../../../../store/StoreContext';
 
+import translations from './translations.json';
 import './artefact-overview.scss';
 
 export type ArtefactOverviewItem = {
@@ -34,6 +36,7 @@ export enum ArtefactOverviewType {
   CARD = 'card',
   CARD_SMALL = 'card-small',
   LIST = 'list',
+  TABLE = 'table',
 }
 
 type OverviewProps = {
@@ -50,7 +53,9 @@ const Overview: FC<OverviewProps> = ({
   viewType = DefaultViewType,
   handleArtefactAmountChange = () => {},
 }) => {
-  const { root: { collection } } = useContext(StoreContext);
+  const { root: { collection, ui } } = useContext(StoreContext);
+
+  const { t } = ui.useTranslation('ArtefactOverview', translations);
 
   const artefactOverviewElRef = useRef<HTMLDivElement | null>(null);
   const hasHighlightedText = (item: ArtefactOverviewItem, prop: keyof ArtefactOverviewItem): boolean => {
@@ -189,6 +194,55 @@ const Overview: FC<OverviewProps> = ({
     }
   };
 
+  const tableData = ((artifactKind: UIArtifactKind, items: ArtefactOverviewItem[]): Pick<ArtefactTableProps, 'head' | 'items'> => {
+    if (items.length === 0) {
+      return {
+        head: [],
+        items: [],
+      };
+    }
+
+    if ([UIArtifactKind.WORKS, UIArtifactKind.PAINTINGS].includes(artifactKind)) {
+      return {
+        head: [
+          { fieldName: 'title', text: t('Title') },
+          { fieldName: 'artist', text: t('Artist'), options: { noWrap: true } },
+          { fieldName: 'medium', text: t('Medium') },
+          { fieldName: 'repository', text: t('Repository') },
+          { fieldName: 'date', text: t('Date'), options: { noWrap: true } },
+        ],
+        items: items.map((item) => ({
+          id: item.id,
+          to: item.to,
+          imgSrc: item.imgSrc,
+          imgAlt: '',
+          date: item.date,
+          title: item.title,
+          medium: item.medium,
+          artist: item.artist,
+          repository: item.repository,
+          isFavorite: isFavorite(item.id),
+        })),
+      };
+    }
+
+    return {
+      head: [
+        { fieldName: 'date', text: t('Date'), options: { noWrap: true } },
+        { fieldName: 'summary', text: t('Summary') },
+      ],
+      items: items.map((item) => ({
+        id: item.id,
+        to: item.to,
+        imgSrc: item.imgSrc,
+        imgAlt: '',
+        date: item.date,
+        summary: item.title,
+        isFavorite: isFavorite(item.id),
+      })),
+    };
+  })(ui.artifactKind, items);
+
   useEffect(() => {
     if (!artefactOverviewElRef.current) return;
 
@@ -202,12 +256,21 @@ const Overview: FC<OverviewProps> = ({
 
   return (<div
     ref={ artefactOverviewElRef }
-    className="artefact-overview"
+    className={`artefact-overview ${ ArtefactOverviewType.TABLE === viewType ? 'artefact-overview--is-table' : 'artefact-overview--is-grid' }`}
     data-component="structure/visualizing/artefact-overview"
     data-active-view={viewType}
   >
     {
-      items.map(item => (<div
+      ArtefactOverviewType.TABLE === viewType && <ArtefactTable
+        head={ tableData.head }
+        items={ tableData.items }
+        getIsFavorite={isFavorite}
+        onFavoriteToggle={toggleFavorite}
+      ></ArtefactTable>
+    }
+
+    {
+      ArtefactOverviewType.TABLE !== viewType && items.map(item => (<div
         key={item.id}
         className="overview-item"
         data-sorting-number={item.searchSortingNumber}
@@ -272,15 +335,19 @@ const OverviewSwitcher: FC<SwitcherProps> = ({
   const allViewEntries = [
     {
       type: ArtefactOverviewType.CARD,
-      icon: 'view_column',
+      icon: 'view_module',
     },
     {
       type: ArtefactOverviewType.CARD_SMALL,
-      icon: 'view_module',
+      icon: 'view_comfy',
     },
     {
       type: ArtefactOverviewType.LIST,
       icon: 'view_list',
+    },
+    {
+      type: ArtefactOverviewType.TABLE,
+      icon: 'view_headline',
     },
   ];
 
@@ -291,8 +358,9 @@ const OverviewSwitcher: FC<SwitcherProps> = ({
       >
         <i
           className={`icon artefact-overview-switcher-item-icon ${(type === viewType) ? 'is-active' : ''}`}
+          data-icon={icon}
           onClick={() => handleChange(type)}
-        >{icon}</i>
+        ></i>
       </Switcher.Item>
     ))}
   </Switcher>);

--- a/src/components/structure/visualizing/artefact-overview/artefact-overview.tsx
+++ b/src/components/structure/visualizing/artefact-overview/artefact-overview.tsx
@@ -229,7 +229,7 @@ const Overview: FC<OverviewProps> = ({
     return {
       head: [
         { fieldName: 'date', text: t('Date'), options: { noWrap: true } },
-        { fieldName: 'summary', text: t('Summary') },
+        { fieldName: 'summary', text: t('Summary'), options: { forceColumnTextWrap: true } },
       ],
       items: items.map((item) => ({
         id: item.id,

--- a/src/components/structure/visualizing/artefact-overview/translations.json
+++ b/src/components/structure/visualizing/artefact-overview/translations.json
@@ -1,0 +1,10 @@
+{
+  "de": {
+    "Title": "Titel",
+    "Medium": "Medium",
+    "Artist": "Künstler",
+    "Repository": "Besitzer",
+    "Date": "Datum",
+    "Summary": "Zusammenfassung"
+  }
+}

--- a/src/components/structure/visualizing/artefact-table/artefact-table.scss
+++ b/src/components/structure/visualizing/artefact-table/artefact-table.scss
@@ -22,7 +22,7 @@
   tbody {
     tr {
       td {
-        padding: 0 $s;
+        padding: $s $s;
         vertical-align: middle;
         background-color: $lighter;
         border-bottom: solid $border-stroke-weight-s $accent;

--- a/src/components/structure/visualizing/artefact-table/artefact-table.scss
+++ b/src/components/structure/visualizing/artefact-table/artefact-table.scss
@@ -26,6 +26,14 @@
         vertical-align: middle;
         background-color: $lighter;
         border-bottom: solid $border-stroke-weight-s $accent;
+
+        & .text-value {
+          display: inline-block;
+
+          &.wrap {
+            width: 80ch;
+          }
+        }
       }
 
       #{$self}__image-field {

--- a/src/components/structure/visualizing/artefact-table/artefact-table.scss
+++ b/src/components/structure/visualizing/artefact-table/artefact-table.scss
@@ -1,0 +1,93 @@
+@import "../../../../style//000-abstracts/__abstracts-dir";
+
+.artefact-table {
+  position: relative;
+  overflow: hidden;
+  border-collapse: separate;
+  border-spacing: 0 $xs;
+  width: 100%;
+
+  $self: &;
+
+  thead {
+    tr {
+      th {
+        text-align: left;
+        padding: 0 $s;
+        font-weight: $fw-semibold;
+      }
+    }
+  }
+
+  tbody {
+    tr {
+      td {
+        padding: 0 $s;
+        vertical-align: middle;
+        background-color: $lighter;
+        border-bottom: solid $border-stroke-weight-s $accent;
+      }
+
+      #{$self}__image-field {
+        padding: $xxs $m;
+        width: $xl;
+      }
+
+      #{$self}__favorite {
+        padding: 0;
+        overflow: hidden;
+
+        .favorite-holder {
+          position: relative;
+          width: $xl;
+          height: $l;
+
+          .favorite {
+            top: 0px;
+            position: absolute;
+            right: $xs;
+            aspect-ratio: 1/1;
+            background-color: $lighten-strongest;
+            border-radius: 50%;
+            color: $dark;
+            transition: transform $tr-fast, color $tr-fast, opacity $tr-medium, top $tr-medium;
+            opacity: 1;
+
+            &:hover,
+            &--is-active {
+              background-color: $accent;
+              color: $lightest;
+              cursor: pointer;
+            }
+
+            &--is-armed {
+              top: -50px;
+              opacity: 0;
+            }
+
+            &--is-active {
+              transform: scale(1);
+            }
+          }
+        }
+      }
+
+      &:hover{
+        background-color: $darken-strong;
+
+        #{$self}__favorite {
+          .favorite-holder {
+            .favorite {
+              top: 0 !important;
+              opacity: 1 !important;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  .no-wrap {
+    white-space: nowrap;
+  }
+}

--- a/src/components/structure/visualizing/artefact-table/artefact-table.tsx
+++ b/src/components/structure/visualizing/artefact-table/artefact-table.tsx
@@ -1,0 +1,92 @@
+import React, { FC, useEffect, useState } from 'react';
+
+import Image from '../../../base/visualizing/image';
+
+import './artefact-table.scss';
+
+
+interface ItemProp {
+  id: string;
+  to: string;
+  imgSrc: string;
+  imgAlt: string;
+  isFavorite: boolean;
+  [key: string]: string | boolean;
+}
+
+export type Props = {
+  head: {
+    fieldName: string,
+    text: string,
+    options?: {
+      noWrap?: boolean,
+    },
+  }[],
+  items: ItemProp[],
+  getIsFavorite: (id: string) => boolean,
+  onFavoriteToggle: (id: string) => void,
+}
+
+const ArtefactTable: FC<Props> = ({
+  head,
+  items,
+  onFavoriteToggle,
+}) => {
+
+  // const additionalTextString = additionalText.map((item, index) => (<p key={index} className="artefact-line__text">{item}</p>));
+
+  const [isArmed, setIsArmed] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => { setIsArmed(true); }, 1000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (<table
+    className="artefact-table"
+    data-component="structure/visualizing/artefact-table"
+  >
+    <thead>
+      <tr>
+        <th scope="col"></th>
+        { head.map((headItem) => (<th scope="col">{headItem.text}</th>)) }
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {
+        items.map((item) => {
+          return (
+            <tr>
+              <td
+                scope="row"
+                className="artefact-table__image-field"
+              >
+                <a href={item.to}>
+                  <Image
+                    src={item.imgSrc || ''}
+                    alt={item.imgAlt}
+                    modifierWithBox={true} // -has-box artefact-line-image
+                  />
+                </a>
+              </td>
+              {
+                head.map((headItem) => (<td className={headItem.options?.noWrap ? 'no-wrap' : ''}>{ item[headItem.fieldName] }</td>))
+              }
+              <td className="artefact-table__favorite">
+                  <div className="favorite-holder">
+                    <a
+                      className={`favorite icon ${item.isFavorite ? 'favorite--is-active' : ''} ${isArmed ? 'favorite--is-armed' : ''}`}
+                      onClick={() => { onFavoriteToggle(item.id) }}
+                    >{item.isFavorite ? 'remove' : 'add'}</a>
+                  </div>
+              </td>
+            </tr>
+          );
+        })
+      }
+    </tbody>
+  </table>);
+};
+
+export default ArtefactTable;

--- a/src/components/structure/visualizing/artefact-table/artefact-table.tsx
+++ b/src/components/structure/visualizing/artefact-table/artefact-table.tsx
@@ -23,7 +23,6 @@ export type Props = {
     },
   }[],
   items: ItemProp[],
-  getIsFavorite: (id: string) => boolean,
   onFavoriteToggle: (id: string) => void,
 }
 

--- a/src/components/structure/visualizing/artefact-table/artefact-table.tsx
+++ b/src/components/structure/visualizing/artefact-table/artefact-table.tsx
@@ -32,8 +32,6 @@ const ArtefactTable: FC<Props> = ({
   onFavoriteToggle,
 }) => {
 
-  // const additionalTextString = additionalText.map((item, index) => (<p key={index} className="artefact-line__text">{item}</p>));
-
   const [isArmed, setIsArmed] = useState(false);
 
   useEffect(() => {

--- a/src/components/structure/visualizing/artefact-table/artefact-table.tsx
+++ b/src/components/structure/visualizing/artefact-table/artefact-table.tsx
@@ -20,6 +20,7 @@ export type Props = {
     text: string,
     options?: {
       noWrap?: boolean,
+      forceColumnTextWrap?: boolean,
     },
   }[],
   items: ItemProp[],
@@ -68,7 +69,13 @@ const ArtefactTable: FC<Props> = ({
                 </a>
               </td>
               {
-                head.map((headItem) => (<td className={headItem.options?.noWrap ? 'no-wrap' : ''}>{ item[headItem.fieldName] }</td>))
+                head.map((headItem) => (
+                  <td className={headItem.options?.noWrap ? 'no-wrap' : ''}>
+                    <span className={`text-value ${headItem.options?.forceColumnTextWrap ? 'wrap' : ''}`}>
+                      { item[headItem.fieldName] }
+                    </span>
+                  </td>)
+                )
               }
               <td className="artefact-table__favorite">
                   <div className="favorite-holder">

--- a/src/components/structure/visualizing/artefact-table/index.ts
+++ b/src/components/structure/visualizing/artefact-table/index.ts
@@ -1,0 +1,4 @@
+import ArtefactTable from './artefact-table';
+export type { Props } from './artefact-table';
+
+export default ArtefactTable;

--- a/src/store/domains/ui.ts
+++ b/src/store/domains/ui.ts
@@ -349,6 +349,7 @@ export enum UIOverviewViewType {
   CARD = 'card',
   CARD_SMALL = 'card-small',
   LIST = 'list',
+  TABLE = 'table',
 }
 export type UIDimensionsType = {
    width: number,


### PR DESCRIPTION
Mit diesem PR wird die Komponente ArtifactOverview um eine tabellarische Ansicht erweitert, um z.B. die Archivalien besser auflisten und ausgeben zu können.

Sollte erst nach folgendem PR abgearbeitet werden: https://github.com/lucascranach/cranach-search/pull/94