### PR TITLE
fix(collection): rework jump into filter- and collection-sidebar

### DIFF
--- a/src/components/pages/dashboard/dashboard.tsx
+++ b/src/components/pages/dashboard/dashboard.tsx
@@ -10,7 +10,7 @@ import Cloak from '../../base/visualizing/cloak';
 import SearchResultNavigation from '../../structure/interacting/search-result-navigation';
 import Navigation from '../../structure/interacting/navigation';
 import ScrollTo from '../../base/interacting/scroll-to';
-import StoreContext, { UIOverviewViewType, EntityType, UIArtifactKind } from '../../../store/StoreContext';
+import StoreContext, { UIOverviewViewType, EntityType, UIArtifactKind, UISidebarContentType } from '../../../store/StoreContext';
 
 import translations from './translations.json';
 import './dashboard.scss';
@@ -26,8 +26,8 @@ const Dashboard: FC = () => {
   const maximumTitleLengthInWords = 10;
 
   useEffect(() => {
-    lighttable.fetch();
-  }, [])
+    ui.fetchForCurrentSideBarContent();
+  }, []);
 
   useEffect(() => {
     if (window.scrollY < window.innerHeight) return;
@@ -182,7 +182,10 @@ const Dashboard: FC = () => {
       };
     }
 
-    if (artifactKind & UIArtifactKind.WORKS) {
+    const workArtefactsSelected = artifactKind & UIArtifactKind.WORKS;
+    const myCranachIsVisible = ui.sidebarContent === UISidebarContentType.MY_CRANACH;
+
+    if (workArtefactsSelected || myCranachIsVisible) {
       return {
         head: [
           { fieldName: 'title', text: t('Title') },

--- a/src/components/structure/interacting/navigation/translations.json
+++ b/src/components/structure/interacting/navigation/translations.json
@@ -1,14 +1,9 @@
 {
   "de": {
-    "Prints and Drawings": "Drucke und Zeichnungen",
+    "All Objects": "Alle Werke",
     "Paintings": "Gemälde",
+    "Prints and Drawings": "Drucke und Zeichnungen",
     "Archival Documents": "Archivalien",
-    "Publications": "Literatur",
-    "My Collection": "Meine Sammlung",
-    "back to the overview": "zurück zur Übersicht",
-    "Go to my Collection": "Meine Sammlung zeigen",
-    "Go to search": "Suche zeigen",
-    "All Departments": "Alle Abteilungen",
-    "All Objects": "Alle Werke"
+    "Publications": "Literatur"
   }
 }

--- a/src/components/structure/interacting/secondary-navigation/secondary-navigation.tsx
+++ b/src/components/structure/interacting/secondary-navigation/secondary-navigation.tsx
@@ -28,12 +28,10 @@ const SecondaryNavigation = () => {
 
   const showMyCranach = () => {
     ui.setSideBarContent(UISidebarContentType.MY_CRANACH);
-    collection.showCollection();
   }
 
   const showFilter = () => {
     ui.setSideBarContent(UISidebarContentType.FILTER);
-    lighttable.fetch();
   }
 
   const hideSidebar = () => {
@@ -121,7 +119,7 @@ const SecondaryNavigation = () => {
             onClick={() => hideSidebar()}
           >
             <i className="icon icon--is-inline">minimize</i>
-            {t('hide sidebar')}
+            {t('Hide sidebar')}
           </button>
         </li>
 

--- a/src/components/structure/interacting/secondary-navigation/translations.json
+++ b/src/components/structure/interacting/secondary-navigation/translations.json
@@ -1,15 +1,7 @@
 {
   "de": {
-    "Prints and Drawings": "Drucke und Zeichnungen",
-    "Paintings": "Gemälde",
-    "Archival Documents": "Archivalien",
-    "Literature": "Literatur",
-    "My Collection": "Meine Sammlung",
-    "back to the overview": "zurück zur Übersicht",
-    "goto My Collection": "Meine Sammlung zeigen",
-    "goto search": "Suche zeigen",
-    "All Departments": "Alle Abteilungen",
-    "hide sidebar": "Sidebar minimieren",
-    "All Objects": "Alle Werke"
+    "Go to my Collection": "Meine Sammlung zeigen",
+    "Go to search": "Suche zeigen",
+    "Hide sidebar": "Sidebar minimieren"
   }
 }


### PR DESCRIPTION
Mit diesem MR wird der Sprung zwischen Sammlungs- und Such-/Filter-Ansicht etwas überarbeitet, um u.a. aus der Literatur als aktive Artefakte heraus sauber in die Sammlungsansicht springen zu können.

Zudem springt man automatisch in die Such-/Filter-Ansicht (sofern man vorher in der Sammlungsansicht war), wenn sich der zu betrachtende Artefakttyp ändert.

