### PR TITLE
feat(literatureReference): publication column rework

### DIFF
--- a/src/api/literature-references.ts
+++ b/src/api/literature-references.ts
@@ -16,7 +16,7 @@ const sortingFieldnameMapping: Record<string, string> = {
   'authors': 'authors',
   'publishLocation': 'publish_location',
   'publishDate': 'publish_date',
-  'textCategory': 'text_category',
+  'publications': 'publications',
 };
 
 const assembleResultData = (resultset: any): GlobalSearchResponse => {
@@ -145,7 +145,7 @@ export const toArtefact = (item: any): LiteratureReferenceSearchArtifact => {
     title: item.title,
     subtitle: item.subtitle,
     journal: item.journal,
-    textCategory: item.text_category,
+    publications: item.publications,
     date: item.dating,
     referenceNumber: item.reference_number,
     persons: item.persons,
@@ -156,6 +156,13 @@ export const toArtefact = (item: any): LiteratureReferenceSearchArtifact => {
   };
 };
 
+interface LiteratureReferencePublication {
+  type: string;
+  text: string;
+  remarks: string;
+  subPublications: LiteratureReferencePublication[];
+}
+
 export interface LiteratureReferenceSearchArtifact {
   kind: ArtifactKind.LITERATURE_REFERENCE;
   id: string;
@@ -163,7 +170,7 @@ export interface LiteratureReferenceSearchArtifact {
   title: string;
   subtitle: string;
   journal: string;
-  textCategory: string;
+  publications: LiteratureReferencePublication[];
   date: string;
   referenceNumber: string;
   persons: { role: string, name: string }[],

--- a/src/api/literature-references.ts
+++ b/src/api/literature-references.ts
@@ -16,7 +16,7 @@ const sortingFieldnameMapping: Record<string, string> = {
   'authors': 'authors',
   'publishLocation': 'publish_location',
   'publishDate': 'publish_date',
-  'publications': 'publications',
+  'mediaType': 'publications_line',
 };
 
 const assembleResultData = (resultset: any): GlobalSearchResponse => {
@@ -72,6 +72,11 @@ const getQueryStringForFilters = (
   const cleanYear = freetextFields.year.trim();
   if (cleanYear) {
     params['publish_date:sim'] = cleanYear;
+  }
+
+  const cleanMediaType = freetextFields.mediaType.trim();
+  if (cleanMediaType) {
+    params['publication_text:sim'] = cleanMediaType;
   }
 
   if (sorting.length > 0) {
@@ -146,6 +151,7 @@ export const toArtefact = (item: any): LiteratureReferenceSearchArtifact => {
     subtitle: item.subtitle,
     journal: item.journal,
     publications: item.publications,
+    mediaType: item.publications_line,
     date: item.dating,
     referenceNumber: item.reference_number,
     persons: item.persons,
@@ -171,6 +177,7 @@ export interface LiteratureReferenceSearchArtifact {
   subtitle: string;
   journal: string;
   publications: LiteratureReferencePublication[];
+  mediaType: string;
   date: string;
   referenceNumber: string;
   persons: { role: string, name: string }[],
@@ -197,4 +204,5 @@ export interface LiteratureReferencesAPIFreetextFieldsType {
   authors: string,
   signature: string,
   year: string,
+  mediaType: string,
 };

--- a/src/components/pages/dashboard/dashboard.tsx
+++ b/src/components/pages/dashboard/dashboard.tsx
@@ -232,7 +232,7 @@ const Dashboard: FC = () => {
             noWrapHead: true,
           }},
 
-          { fieldName: 'publishLocation', text: t('Place of Publication'), options: {
+          { fieldName: 'publishLocation', text: t('Place'), options: {
             sort: lighttable.getSortingForFieldname('publishLocation'),
             noWrapHead: true,
           }},

--- a/src/components/pages/dashboard/dashboard.tsx
+++ b/src/components/pages/dashboard/dashboard.tsx
@@ -227,11 +227,15 @@ const Dashboard: FC = () => {
             noWrapHead: true,
             linkify: true,
           }},
+          { fieldName: 'title', text: t('Title'), options: {
+            sort: lighttable.getSortingForFieldname('title'),
+            asInnerHTML: true,
+            noWrapHead: true,
+          }},
           { fieldName: 'authors', text: t('Author/Editor'), options: {
             sort: lighttable.getSortingForFieldname('authors'),
             noWrapHead: true,
           }},
-
           { fieldName: 'publishLocation', text: t('Place'), options: {
             sort: lighttable.getSortingForFieldname('publishLocation'),
             noWrapHead: true,
@@ -243,11 +247,6 @@ const Dashboard: FC = () => {
           { fieldName: 'mediaType', text: t('Media type'), options: {
             sort: lighttable.getSortingForFieldname('mediaType'),
             noWrap: true,
-            noWrapHead: true,
-          }},
-          { fieldName: 'title', text: t('Title'), options: {
-            sort: lighttable.getSortingForFieldname('title'),
-            asInnerHTML: true,
             noWrapHead: true,
           }},
         ],

--- a/src/components/pages/dashboard/dashboard.tsx
+++ b/src/components/pages/dashboard/dashboard.tsx
@@ -240,8 +240,8 @@ const Dashboard: FC = () => {
             sort: lighttable.getSortingForFieldname('publishDate'),
             noWrapHead: true,
           }},
-          { fieldName: 'textCategory', text: t('Text Category'), options: {
-            sort: lighttable.getSortingForFieldname('textCategory'),
+          { fieldName: 'mediaType', text: t('Media type'), options: {
+            sort: lighttable.getSortingForFieldname('mediaType'),
             noWrap: true,
             noWrapHead: true,
           }},
@@ -261,7 +261,7 @@ const Dashboard: FC = () => {
           publishLocation : item.kind === ArtifactKind.LITERATURE_REFERENCE ? item.publishLocation : '',
           publishDate: item.kind === ArtifactKind.LITERATURE_REFERENCE ? item.publishDate : '',
 
-          textCategory: item.kind === ArtifactKind.LITERATURE_REFERENCE ? item.textCategory : '',
+          mediaType: item.kind === ArtifactKind.LITERATURE_REFERENCE ? item.publications.map((publication) => publication.text).join(', ') : '',
 
           title: item.title,
 

--- a/src/components/pages/dashboard/dashboard.tsx
+++ b/src/components/pages/dashboard/dashboard.tsx
@@ -260,7 +260,7 @@ const Dashboard: FC = () => {
           publishLocation : item.kind === ArtifactKind.LITERATURE_REFERENCE ? item.publishLocation : '',
           publishDate: item.kind === ArtifactKind.LITERATURE_REFERENCE ? item.publishDate : '',
 
-          mediaType: item.kind === ArtifactKind.LITERATURE_REFERENCE ? item.publications.map((publication) => publication.text).join(', ') : '',
+          mediaType: item.kind === ArtifactKind.LITERATURE_REFERENCE ? item.mediaType : '',
 
           title: item.title,
 

--- a/src/components/pages/dashboard/translations.json
+++ b/src/components/pages/dashboard/translations.json
@@ -9,7 +9,7 @@
 
     "Signature": "Kürzel",
     "Author/Editor": "Autor/In, Herausgeber/In",
-    "Place of Publication": "Ort der Veröffentlichung",
+    "Place": "Ort",
     "Year": "Jahr",
     "Media type": "Medientyp",
     "Title": "Titel",

--- a/src/components/pages/dashboard/translations.json
+++ b/src/components/pages/dashboard/translations.json
@@ -11,7 +11,7 @@
     "Author/Editor": "Autor/In, Herausgeber/In",
     "Place of Publication": "Ort der Veröffentlichung",
     "Year": "Jahr",
-    "Text Category": "Textart",
+    "Media type": "Medientyp",
     "Title": "Titel",
 
     "Journal": "Zeitschrift",

--- a/src/components/structure/interacting/search-literature-references/search-literature-references.tsx
+++ b/src/components/structure/interacting/search-literature-references/search-literature-references.tsx
@@ -94,6 +94,16 @@ const SearchArchivals: FC = () => {
             onReset={ triggerFilterRequest }
             resetable={true}
           ></TextInput>
+
+          <TextInput
+            className="search-input"
+            label={ t('Media type') }
+            value={ searchLiteratureReferences.freetextFields.mediaType }
+            onChange={ mediaType => searchLiteratureReferences.setFreetextFields({ mediaType }) }
+            onKeyDown={ triggerFilterRequestOnEnter }
+            onReset={ triggerFilterRequest }
+            resetable={true}
+          ></TextInput>
         </Toggle>
 
         <Btn

--- a/src/components/structure/interacting/search-literature-references/translations.json
+++ b/src/components/structure/interacting/search-literature-references/translations.json
@@ -10,6 +10,7 @@
     "Author": "Autor/In, Herausgeber/In",
     "Signature": "Kürzel",
     "Year": "Jahr",
+    "Media type": "Medientyp",
     "Advanced Search": "Erweiterte Suche"
   }
 }

--- a/src/components/structure/visualizing/artefact-table/artefact-table.scss
+++ b/src/components/structure/visualizing/artefact-table/artefact-table.scss
@@ -68,10 +68,14 @@
   tbody {
     tr {
       td {
-        padding: $s $s;
+        padding: $s 0 $s $s;
         vertical-align: middle;
         background-color: $lighter;
         border-bottom: solid $border-stroke-weight-s $accent;
+
+        &:last-child {
+          padding-right: $s;
+        }
 
         a {
           border-bottom: 1px solid $accent;

--- a/src/store/domains/searchLiteratureReferences.ts
+++ b/src/store/domains/searchLiteratureReferences.ts
@@ -49,6 +49,7 @@ const createInitialFreeTexts = (): FreeTextFields => ({
   authors: '',
   signature: '',
   year: '',
+  mediaType: '',
 });
 
 const createInitialFilters = (): FilterType => ({
@@ -262,6 +263,7 @@ export default class SearchLiteratureReferences implements SearchLiteratureRefer
             case 'authors':
             case 'signature':
             case 'year':
+            case 'media_type':
               this.handleRoutingNotificationForFreetext(name, value);
               break;
           }
@@ -321,6 +323,7 @@ export default class SearchLiteratureReferences implements SearchLiteratureRefer
 
     const keyMap: Record<string, string> = {
       'allFieldsTerm': 'search_term',
+      'mediaType': 'media_type',
     };
 
     Object.entries(this.freetextFields).forEach(([key, value]) => {
@@ -379,6 +382,10 @@ export default class SearchLiteratureReferences implements SearchLiteratureRefer
       case 'year':
         this.freetextFields.year = value;
         break;
+
+      case 'media_type':
+        this.freetextFields.mediaType = value;
+        break;
     }
   }
 
@@ -393,6 +400,7 @@ export interface FreeTextFields {
   authors: string;
   signature: string;
   year: string;
+  mediaType: string;
 }
 
 export interface SearchLiteratureReferencesStoreInterface {


### PR DESCRIPTION
Mit diesem PR wird aus der Publikationsspalte eine Medientypspalte. In dem Rahmen werden nun auch die wirklichen Publikationsdaten für diese Spalte aufgegriffen, anstatt auf aggregrierte Werte aufsetzen zu müssen.

Hängt zusammen mit folgendem PR: https://github.com/lucascranach/cranach-api/pull/135