### PR TITLE
Dynamische Bestimmung der Artefakt-Anzahl in der Übersicht

### DIFF
--- a/src/components/pages/dashboard/dashboard.scss
+++ b/src/components/pages/dashboard/dashboard.scss
@@ -9,6 +9,7 @@
 
   .scroll-up {
     position: fixed;
+    z-index: 100;
     right: 1rem;
     bottom: 1rem;
     display: none;

--- a/src/components/pages/dashboard/dashboard.tsx
+++ b/src/components/pages/dashboard/dashboard.tsx
@@ -346,7 +346,14 @@ const Dashboard: FC = () => {
       >
         <ArtefactOverview.Overview
           viewType={mapSelectedOverviewViewType(ui.overviewViewType)}
-          handleArtefactAmountChange={ (amount: number) => lighttable.setSize(amount) }
+          handleArtefactAmountChange={ (amount: number) => {
+            lighttable.setSize(amount);
+            lighttable.fetch();
+          } }
+          resetArtefactAmount={ () => {
+            lighttable.resetSize();
+            lighttable.fetch();
+          } }
         >
           {
 

--- a/src/components/structure/visualizing/artefact-overview/artefact-overview.scss
+++ b/src/components/structure/visualizing/artefact-overview/artefact-overview.scss
@@ -4,7 +4,6 @@
 .artefact-overview {
   height: 100%;
   align-content: flex-start;
-  padding-bottom: $xxl;
 
   &--is-grid {
     display: grid;
@@ -15,8 +14,7 @@
     &[data-active-view="card-small"] {
       @include grid-auto-columns-small();
 
-      column-gap: $xxs !important;
-      row-gap: $xxs !important;
+      gap: $xxs;
     }
 
     &[data-active-view="list"] {

--- a/src/components/structure/visualizing/artefact-overview/artefact-overview.tsx
+++ b/src/components/structure/visualizing/artefact-overview/artefact-overview.tsx
@@ -13,6 +13,7 @@ export enum ArtefactOverviewType {
 type OverviewProps = {
   viewType: ArtefactOverviewType,
   handleArtefactAmountChange?: (amount: number) => void;
+  resetArtefactAmount?: () => void;
 }
 
 const DefaultViewType = ArtefactOverviewType.CARD;
@@ -20,6 +21,7 @@ const DefaultViewType = ArtefactOverviewType.CARD;
 const Overview: FC<OverviewProps> = ({
   viewType = DefaultViewType,
   handleArtefactAmountChange = () => {},
+  resetArtefactAmount = () => {},
   children,
 }) => {
   const artefactOverviewElRef = useRef<HTMLDivElement | null>(null);
@@ -33,8 +35,7 @@ const Overview: FC<OverviewProps> = ({
       'height': elRef.clientHeight
     };
 
-    const safetyDistance = 1;
-    const rows = Math.floor(artefactOverviewDimensions.height / tileSize) - safetyDistance;
+    const rows = Math.floor(artefactOverviewDimensions.height / tileSize);
     const cols = Math.floor(artefactOverviewDimensions.width / tileSize);
 
     return cols * rows;
@@ -55,6 +56,8 @@ const Overview: FC<OverviewProps> = ({
       window.addEventListener('resize', setFittedArtefactAmount);
 
       return () => window.removeEventListener('resize', setFittedArtefactAmount);
+    } else {
+      resetArtefactAmount();
     }
   }, [viewType, artefactOverviewElRef]);
 

--- a/src/store/domains/lighttable.ts
+++ b/src/store/domains/lighttable.ts
@@ -24,6 +24,13 @@ import {
 import { UIArtifactKind as LighttableArtifactKind } from './ui';
 export { UIArtifactKind as LighttableArtifactKind } from './ui';
 
+const initialValues = {
+  pagination: {
+    size: 60,
+    from: 0,
+  },
+};
+
 export default class Lighttable implements LighttableStoreInterface, RoutingObservableInterface {
   rootStore: RootStoreInterface;
   providers: LighttableProviderInterface[] = [];
@@ -32,8 +39,8 @@ export default class Lighttable implements LighttableStoreInterface, RoutingObse
   result: GlobalSearchResult | null = null;
   error: string | null = null;
   pagination = {
-    size: 60,
-    from: 0,
+    size: initialValues.pagination.size,
+    from: initialValues.pagination.from,
   };
   sorting: SortingItem[] = [];
 
@@ -146,6 +153,10 @@ export default class Lighttable implements LighttableStoreInterface, RoutingObse
     if (this.pagination.size === size) return;
 
     this.pagination.size = size;
+  }
+
+  resetSize() {
+    this.pagination = {...initialValues.pagination};
   }
 
   setFrom(from: number) {
@@ -301,6 +312,7 @@ export interface LighttableStoreInterface {
   jumpToPagePos(pagePos: number): void;
   setResultFetchingFailed(error: string | null): void;
   setSize(size: number): void;
+  resetSize(): void;
   setFrom(from: number): void;
   resetPagePos(): void;
   setSortingForFieldname(fieldName: string, direction: SortingDirection | null): void;

--- a/src/style/010-base/content.scss
+++ b/src/style/010-base/content.scss
@@ -1,5 +1,4 @@
 .main-content {
-  padding: $m;
-  padding-top: 0;
+  padding: 0 $m 0 $m;
   background-color: $lightest;
 }


### PR DESCRIPTION
@cnoss Hierzu müssten wir am besten mal sprechen, da eine Lösung für das Problem mit der nicht vollständig aufgefüllten letzten Ergebnisreihe erarbeitet werden müsste.

Das Konstrukt aus `--tile-fix` und der darüber dynamisch bestimmten Anzahl von Artefakten pro Spalte und Zeile ist leider etwas ungenau. Da das Grid mittels CSS-Grid aufgebaut wird, ist es von JS losgelöst, wodurch die Anzahl der Grid-Elemente auf den beiden Axen leider nicht genau deckungsgleich berechnet und bestimmt werden kann.
Wir veruschen somit aktuell unabhängig voneinander (CSS und JS) auf die selben Werte zu kommen, damit auf Seitens JS die korrekte `size` an die API gesendet werden kann.

Vllt. muss die Anzahl von JS aus bestimmt und dann Richtung CSS propagiert (vllt. mit CSS custom property) werden.