### PR TITLE
Zeichnungen werden in den Filter miteinbezogen

### DIFF
--- a/src/store/domains/lighttable.ts
+++ b/src/store/domains/lighttable.ts
@@ -72,7 +72,7 @@ export default class Lighttable implements LighttableStoreInterface, RoutingObse
 
   get entityTypes(): Set<EntityType> {
     const artifactKindToEntityTypeMap: Record<LighttableArtifactKind, EntityType[]> = {
-      [LighttableArtifactKind.WORKS]: [EntityType.PAINTING, EntityType.GRAPHIC],
+      [LighttableArtifactKind.WORKS]: [EntityType.PAINTING, EntityType.GRAPHIC, EntityType.DRAWING],
       [LighttableArtifactKind.PAINTINGS]: [EntityType.PAINTING],
       [LighttableArtifactKind.ARCHIVALS]: [EntityType.ARCHIVAL],
       [LighttableArtifactKind.PRINTS]: [EntityType.GRAPHIC],


### PR DESCRIPTION
Zeichnungen werden in den Filter miteinbezogen

<img width="1507" alt="Screenshot 2024-10-25 at 12 20 14" src="https://github.com/user-attachments/assets/03bd0a2e-508e-4710-8e42-2b1a20b71054">
