### PR TITLE
Fix buid 140

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -51,6 +51,7 @@ export interface GlobalSearchResult {
   items: GlobalSearchArtifact[];
   meta: {
     hits: number;
+    reprints?: number;
   };
 }
 

--- a/src/components/pages/dashboard/translations.json
+++ b/src/components/pages/dashboard/translations.json
@@ -17,6 +17,7 @@
     "Journal": "Zeitschrift",
     "Article": "Aufsatz",
     "Monography / Miscellany": "Monographie / Sammelband",
+    "Reprint": "Abzug",
     "Reprints": "Abzüge",
     "No Reprints": "Keine Abzüge"
   }

--- a/src/components/structure/interacting/search-works/search-works.scss
+++ b/src/components/structure/interacting/search-works/search-works.scss
@@ -62,6 +62,10 @@
     p {
       line-height: normal;
     }
+
+    &__reprints {
+      font-weight: $fw-regular;
+    }
   }
 
   .logo {

--- a/src/components/structure/interacting/search-works/search-works.tsx
+++ b/src/components/structure/interacting/search-works/search-works.tsx
@@ -28,6 +28,7 @@ const SearchWorks: FC = () => {
 
   const filterCount = searchWorks.amountOfActiveFilters;
   const hits = lighttable.result?.meta.hits ?? 0;
+  const reprints = lighttable.result?.meta.reprints ?? 0;
   const catalogWorkReferenceNames = 'Friedländer, Rosenberg (1978)';
 
   const filterGroups = searchWorks.filters.groups ?? [];
@@ -83,6 +84,8 @@ const SearchWorks: FC = () => {
       <div className="search-result-info">
         {hits === 1 && <p><Size size={hits} /> {t('work found')}</p>}
         {(hits > 1 || hits === 0) && <p><Size size={hits} /> { t('works found') }</p>}
+        {reprints === 1 && <p className="search-result-info__reprints"><Size size={reprints} /> {t('reprint found')}</p>}
+        {reprints > 1 && <p className="search-result-info__reprints"><Size size={reprints} /> {t('reprints found')}</p>}
       </div>
       <fieldset className="block keyword-search">
         <TextInput

--- a/src/components/structure/interacting/search-works/translations.json
+++ b/src/components/structure/interacting/search-works/translations.json
@@ -14,6 +14,8 @@
     "Examination Techniques": "Untersuchungstechniken",
     "work found": "Werk gefunden",
     "works found": "Werke gefunden",
+    "reprint found": "Abzug gefunden",
+    "reprints found": "Abzüge gefunden",
     "Search": "Suche",
     "reset filters": "Filter zurücksetzen",
     "Masterpieces": "Meisterwerke",

--- a/src/components/structure/visualizing/artefact-card/artefact-card.tsx
+++ b/src/components/structure/visualizing/artefact-card/artefact-card.tsx
@@ -36,7 +36,11 @@ const ArtefactCard: FC<Props> = ({
   onFavoriteToggle = (() => {}),
   t = ((key: string) => key),
 }) => {
-  const countofReprints = referencesReprintsCount > 0 ? `(${referencesReprintsCount} ${t('Reprints')})` : `(${t('No Reprints')})`;
+  const countofReprints = referencesReprintsCount === 1
+    ? `1 ${t('Reprint')}`
+    : referencesReprintsCount > 1
+      ? `${referencesReprintsCount} ${t('Reprints')}`
+      : t('No Reprints');
 
   const [isArmed, setIsArmed] = useState(false);
 


### PR DESCRIPTION
- Number of reprints is not shown in braces and knows about plural: 1 Abzug, 2 Abzüge
- Display total number of reproductions in timeline for result set (refs #140): Shows the total count of reproductions in the timeline when the result set contains reproductions.  The count is displayed on the right side below the total number of artworks.