### PR TITLE
Pin internal build to mivs02 API via tracked .env.intern

### DIFF
--- a/.env.intern
+++ b/.env.intern
@@ -1,0 +1,1 @@
+VITE_SEARCH_API_URL=https://mivs02.gm.fh-koeln.de

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ dist-ssr
 .vscode/
 .env
 .env.local
-.env.intern
 .env.prod

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ For local development one can also create a `.env.local` not tracked by the VCS,
 
 **Important:** Only environment variables prefixed with a `VITE_` are accessible in the application and are replaced wih their value at build time.
 
+### Modes
+
+The build commands run in different modes, each loading an additional mode specific env file that
+overwrites the values of `.env`:
+
+| Command                | Mode     | Additional env file | API URL                          |
+| ---------------------- | -------- | ------------------- | -------------------------------- |
+| `npm run dev`          | –        | –                   | from `.env`                      |
+| `npm run build:external`| `prod`  | `.env.prod`         | from `.env.prod`                 |
+| `npm run build:internal`| `intern`| `.env.intern`       | `https://mivs02.gm.fh-koeln.de`  |
+
+`.env.intern` is tracked by the VCS, since it only pins the internal API URL and holds no credentials.
+`.env` and `.env.prod` are not tracked and have to be created locally.
+
+In CI the values are passed as process environment variables, which take precedence over the env files.
+
 ## Custom environment variables
 
 | Environment variable            | Description                        | Example                                        |


### PR DESCRIPTION
The intern mode had no mode specific env file, so `npm run build:internal` silently fell back to `.env` - the same values the dev server uses. Add `.env.intern` pinning VITE_SEARCH_API_URL to the internal API server.

Track the file in the VCS (removed from .gitignore): it only contains the API URL and no credentials, which keeps the mode-to-server mapping visible in the repo instead of hidden in the GitHub repository variables.